### PR TITLE
 Don’t reset state on CTAPHID_CANCEL 

### DIFF
--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -234,17 +234,13 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
     }
 
     fn cancel_ongoing_activity(&mut self) {
-        // Remove response if it's there
-        if let Some(_response) = self.interchange.take_response() {
-        } else {
+        if matches!(self.state, State::WaitingOnAuthenticator(_)) {
             info_now!("Interrupting request");
             if let Some(Some(i)) = self.interrupt.map(|i| i.load(Ordering::Relaxed)) {
                 info_now!("Loaded some interrupter");
                 i.interrupt();
             }
         }
-
-        self.state = State::Idle;
     }
 
     /// This method handles CTAP packets (64 bytes), until it has assembled


### PR DESCRIPTION
When we receive a CTAPHID_CANCEL command and cancel a user presence
check, we still need to respond to the original command, typically with
a CTAP2_ERR_KEEPALIVE_CANCEL error.  And if we already finished
executing the command, there is no harm in sending out its response.

With this patch, we never discard responses that have already been
calculated.  Also, we never reset the pipe state and just finish the
normal command flow.  We just set the interrupt flag if the
authenticator is currently processing a command.

*Original description:*
<s>
When cancelling the current request, we previously always reset the pipe state to idle.  This means that an application that is still processing the request would not be allowed to send a response, typically a KEEPALIVE_CANCEL error.

With this patch, we only return to idle state if we discard a prepared response.  Otherwise, we want to trigger the interrupt signal but let the application finish processing so that it can send an appropriate response.
</s>
