### PR TITLE
Remove ctap-types dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctap-types = "0.1.0"
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,4 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-// 1200
-// pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
 pub const MESSAGE_SIZE: usize = 3072;


### PR DESCRIPTION
We only need the ctap-types for six error codes.  It makes more sense to define these error codes directly inside the crate so that we don’t need to make usbd-ctaphid releases just to bump ctap-types.

Arguably, this also makes the code more correct:  Previously, we used a type that represents the CTAP2 error codes, but we actually want to use the CTAPHID error codes.  Those happen to be the same, but it could be a cause for confusion.

In the future, we could also use the ctaphid-types crate instead.