### PR TITLE
Utilize correct MESSAGE_SIZE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 generate-certificate.py
-.DS_Store
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 generate-certificate.py
+.DS_Store

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,9 +2,5 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-// 1200
-// pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
-// pub const MESSAGE_SIZE: usize = 3072;
-// 7609 bytes is max message size for ctaphid
-// ctaphid_dispatch::types::Message.len() == 7069;
-pub const MESSAGE_SIZE: usize = 7069;
+// 7609
+pub const MESSAGE_SIZE: usize = PACKET_SIZE - 7 + 128 * (PACKET_SIZE - 5);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,4 +4,7 @@ pub const PACKET_SIZE: usize = 64;
 
 // 1200
 // pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
-pub const MESSAGE_SIZE: usize = 3072;
+// pub const MESSAGE_SIZE: usize = 3072;
+// 7609 bytes is max message size for ctaphid
+// ctaphid_dispatch::types::Message.len() == 7069;
+pub const MESSAGE_SIZE: usize = 7069;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -35,7 +35,7 @@ use usb_device::{
 
 use crate::{
     constants::{
-        // 3072
+        // 7609
         MESSAGE_SIZE,
         // 64
         PACKET_SIZE,


### PR DESCRIPTION
Prior to commit [1d97873](https://github.com/trussed-dev/usbd-ctaphid/commit/1d97873e72d648a7791ffbf46b922198e7a47511), this value was calculated properly. It was then switched to ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE, which was then removed from the ctap_types package, and it was hardcoded at 3072 for an unknown reason in [a2104a2](https://github.com/trussed-dev/usbd-ctaphid/commit/a2104a29b3fd6fe7b74de779f425dedd053200da).

This PR modifies it back to correctly calculating it as a function of the packet size (giving a max of 7609 with a packet size of 64). The hardcoded 3072 value is insufficient for new post-quantum cryptography algorithms, hence the request to increase it.