### PR TITLE
Update to ctaphid-dispatch v0.3.0 and release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default = []
 
 log-all = []
 log-none = []
+log-trace = []
 log-info = []
 log-debug = []
 log-warn = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctaphid-dispatch = "0.2"
+ctaphid-dispatch = "0.3"
 embedded-time = "0.12"
 delog = "0.1.0"
 heapless-bytes = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usbd-ctaphid"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/src/class.rs
+++ b/src/class.rs
@@ -22,18 +22,18 @@ use usb_device::{
 };
 
 /// Packet-level implementation of the CTAPHID protocol.
-pub struct CtapHid<'alloc, 'pipe, 'interrupt, Bus: UsbBus> {
+pub struct CtapHid<'alloc, 'pipe, 'interrupt, Bus: UsbBus, const N: usize> {
     interface: InterfaceNumber,
-    pipe: Pipe<'alloc, 'pipe, 'interrupt, Bus>,
+    pipe: Pipe<'alloc, 'pipe, 'interrupt, Bus, N>,
 }
 
-impl<'alloc, 'pipe, Bus> CtapHid<'alloc, 'pipe, '_, Bus>
+impl<'alloc, 'pipe, Bus, const N: usize> CtapHid<'alloc, 'pipe, '_, Bus, N>
 where
     Bus: UsbBus,
 {
     pub fn new(
         allocate: &'alloc UsbBusAllocator<Bus>,
-        interchange: Requester<'pipe>,
+        interchange: Requester<'pipe, N>,
         initial_milliseconds: u32,
     ) -> Self {
         // 64 bytes, interrupt endpoint polled every 5 milliseconds
@@ -57,13 +57,13 @@ where
     }
 }
 
-impl<'alloc, 'pipe, 'interrupt, Bus> CtapHid<'alloc, 'pipe, 'interrupt, Bus>
+impl<'alloc, 'pipe, 'interrupt, Bus, const N: usize> CtapHid<'alloc, 'pipe, 'interrupt, Bus, N>
 where
     Bus: UsbBus,
 {
     pub fn with_interrupt(
         allocate: &'alloc UsbBusAllocator<Bus>,
-        interchange: Requester<'pipe>,
+        interchange: Requester<'pipe, N>,
         interrupt: Option<&'interrupt OptionRefSwap<'interrupt, InterruptFlag>>,
         initial_milliseconds: u32,
     ) -> Self {
@@ -112,7 +112,7 @@ where
     }
 
     // implement DerefMut<Target = Pipe> instead
-    pub fn pipe(&mut self) -> &mut Pipe<'alloc, 'pipe, 'interrupt, Bus> {
+    pub fn pipe(&mut self) -> &mut Pipe<'alloc, 'pipe, 'interrupt, Bus, N> {
         &mut self.pipe
     }
 
@@ -218,7 +218,7 @@ pub enum ClassRequests {
     SetProtocol = 0xB,
 }
 
-impl<Bus> UsbClass<Bus> for CtapHid<'_, '_, '_, Bus>
+impl<Bus, const N: usize> UsbClass<Bus> for CtapHid<'_, '_, '_, Bus, N>
 where
     Bus: UsbBus,
 {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,3 @@
 pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
-
-pub const MESSAGE_SIZE: usize = 3072;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -30,15 +30,7 @@ use usb_device::{
     // Result as UsbResult,
 };
 
-use crate::{
-    constants::{
-        // 3072
-        MESSAGE_SIZE,
-        // 64
-        PACKET_SIZE,
-    },
-    types::KeepaliveStatus,
-};
+use crate::{constants::PACKET_SIZE, types::KeepaliveStatus};
 
 // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#usb-hid-error
 // unused variants: InvalidParameter, LockRequired, Other
@@ -149,16 +141,16 @@ pub enum State {
     Sending((Response, MessageState)),
 }
 
-pub struct Pipe<'alloc, 'pipe, 'interrupt, Bus: UsbBus> {
+pub struct Pipe<'alloc, 'pipe, 'interrupt, Bus: UsbBus, const N: usize> {
     read_endpoint: EndpointOut<'alloc, Bus>,
     write_endpoint: EndpointIn<'alloc, Bus>,
     state: State,
 
-    interchange: Requester<'pipe>,
+    interchange: Requester<'pipe, N>,
     interrupt: Option<&'interrupt OptionRefSwap<'interrupt, InterruptFlag>>,
 
     // shared between requests and responses, due to size
-    buffer: [u8; MESSAGE_SIZE],
+    buffer: [u8; N],
 
     // we assign channel IDs one by one, this is the one last assigned
     // TODO: move into "app"
@@ -178,11 +170,11 @@ pub struct Pipe<'alloc, 'pipe, 'interrupt, Bus: UsbBus> {
     pub(crate) version: crate::Version,
 }
 
-impl<'alloc, 'pipe, Bus: UsbBus> Pipe<'alloc, 'pipe, '_, Bus> {
+impl<'alloc, 'pipe, Bus: UsbBus, const N: usize> Pipe<'alloc, 'pipe, '_, Bus, N> {
     pub(crate) fn new(
         read_endpoint: EndpointOut<'alloc, Bus>,
         write_endpoint: EndpointIn<'alloc, Bus>,
-        interchange: Requester<'pipe>,
+        interchange: Requester<'pipe, N>,
         initial_milliseconds: u32,
     ) -> Self {
         Self {
@@ -190,7 +182,7 @@ impl<'alloc, 'pipe, Bus: UsbBus> Pipe<'alloc, 'pipe, '_, Bus> {
             write_endpoint,
             state: State::Idle,
             interchange,
-            buffer: [0u8; MESSAGE_SIZE],
+            buffer: [0u8; N],
             last_channel: 0,
             interrupt: None,
             // Default to nothing implemented.
@@ -203,7 +195,9 @@ impl<'alloc, 'pipe, Bus: UsbBus> Pipe<'alloc, 'pipe, '_, Bus> {
     }
 }
 
-impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus> {
+impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus, const N: usize>
+    Pipe<'alloc, 'pipe, 'interrupt, Bus, N>
+{
     // pub fn borrow_mut_authenticator(&mut self) -> &mut Authenticator {
     //     &mut self.authenticator
     // }
@@ -211,7 +205,7 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
     pub(crate) fn with_interrupt(
         read_endpoint: EndpointOut<'alloc, Bus>,
         write_endpoint: EndpointIn<'alloc, Bus>,
-        interchange: Requester<'pipe>,
+        interchange: Requester<'pipe, N>,
         interrupt: Option<&'interrupt OptionRefSwap<'interrupt, InterruptFlag>>,
         initial_milliseconds: u32,
     ) -> Self {
@@ -220,7 +214,7 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
             write_endpoint,
             state: State::Idle,
             interchange,
-            buffer: [0u8; MESSAGE_SIZE],
+            buffer: [0u8; N],
             last_channel: 0,
             interrupt,
             // Default to nothing implemented.
@@ -363,7 +357,7 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
                 }
             }
 
-            if length > MESSAGE_SIZE as u16 {
+            if length > N as u16 {
                 info!("Error message too big.");
                 self.send_error_now(current_request, AuthenticatorError::InvalidLength);
                 return;


### PR DESCRIPTION
ctaphid-dispatch v0.3.0 makes Dispatch generic over the message size
instead of using a constant value.  This patch adapts usbd-ctaphid to
this patch and changes the usbd-ctaphid buffer to use the same buffer
size as ctaphid-dispatch.  (Previously, we used 3072 and
ctaphid-dispatch used 7609.)  This means that we no longer need the
MESSAGE_SIZE constant and can remove it.

----

Please double-check that we can indeed use the same buffer size for usbd-ctaphid and ctaphid-dispatch.

Depends on:
- https://github.com/trussed-dev/ctaphid-dispatch/pull/16